### PR TITLE
release: v0.1.0b1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [0.1.0b1] - 2026-02-17
+
+### Added
+
+- 12 ATProto lexicon files for the `ac.foundation.dataset` namespace, migrated from [forecast-bio/atdata](https://github.com/forecast-bio/atdata) into NSID-to-path directory structure (`lexicons/ac/foundation/dataset/`)
+  - Record types: `record`, `schema`, `lens`, `label`
+  - Query types: `resolveSchema`, `resolveLabel`
+  - Token/string types: `schemaType`, `arrayFormat`
+  - Storage objects: `storageHttp`, `storageS3`, `storageBlobs`, `storageExternal` (deprecated)
+- NDArray shim JSON Schema in `schemas/ndarray_shim.json`
+- CI validation workflow using `@atproto/lex-cli`
+- PDS publish script (`scripts/publish.sh`) for protocol-level lexicon discovery
+- Lexicon specification docs (`docs/spec.md`)
+
+### Fixed
+
+- Invalid `"type": "object"` property usages in `lens.json` and `schema.json` replaced with proper `#lensMetadata` and `#schemaMetadata` open object defs for lex-cli compatibility


### PR DESCRIPTION
## Summary

First beta release of the standalone `ac.foundation.dataset` lexicon repository.

- **12 ATProto lexicons** migrated from forecast-bio/atdata into NSID-to-path directory structure
- **CI validation** via `@atproto/lex-cli gen-api`
- **PDS publish script** for protocol-level lexicon discovery
- **Lexicon spec docs** in `docs/spec.md`
- **Schema fixes**: invalid `"type": "object"` property usages replaced with proper open object defs (`#lensMetadata`, `#schemaMetadata`)

## Test plan

- [x] `npx lex gen-api` validates all 12 lexicons with zero warnings
- [x] All TypeScript types generated successfully (including previously-skipped `lens.ts` and `schema.ts`)
- [x] Cross-references between lexicons resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)