### PR TITLE
feat: rename record lexicon to entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Authoritative ATProto lexicon definitions for the `science.alt.dataset` namespac
 
 ## Conventions
 
-- Directory structure mirrors NSID: `science.alt.dataset.record` -> `lexicons/science/alt/dataset/record.json`
+- Directory structure mirrors NSID: `science.alt.dataset.entry` -> `lexicons/science/alt/dataset/entry.json`
 - All lexicon files use `"lexicon": 1` and have an `"id"` matching their path-derived NSID
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ lexicons/
   science/
     alt/
       dataset/
-        record.json          # science.alt.dataset.record
+        entry.json           # science.alt.dataset.entry
         schema.json          # science.alt.dataset.schema
         ...
 schemas/
@@ -37,7 +37,7 @@ npx @atproto/lex-cli gen-api ./src/client ./lexicons/science/alt/dataset/*.json
 **Python** (via [atdata](https://github.com/forecast-bio/atdata)):
 ```python
 from atdata.lexicons import load_lexicon
-schema = load_lexicon("science.alt.dataset.record")
+schema = load_lexicon("science.alt.dataset.entry")
 ```
 
 ## Validation

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6,17 +6,17 @@
 
 | NSID | Key | Description |
 |------|-----|-------------|
-| `science.alt.dataset.record` | `tid` | Dataset index record with storage refs, metadata, and sample schema reference |
+| `science.alt.dataset.entry` | `tid` | Dataset index entry with storage refs, metadata, and sample schema reference |
 | `science.alt.dataset.schema` | `any` | Versioned sample type definition (JSON Schema Draft 7, extensible to other formats) |
 | `science.alt.dataset.lens` | `tid` | Bidirectional schema transformation with code references |
-| `science.alt.dataset.label` | `tid` | Named label pointing to a dataset record (enables versioned aliases) |
+| `science.alt.dataset.label` | `tid` | Named label pointing to a dataset entry (enables versioned aliases) |
 
 ### Queries (XRPC)
 
 | NSID | Description |
 |------|-------------|
 | `science.alt.dataset.resolveSchema` | Resolve a schema by NSID, optionally at a specific version |
-| `science.alt.dataset.resolveLabel` | Resolve a named label to its underlying dataset record |
+| `science.alt.dataset.resolveLabel` | Resolve a named label to its underlying dataset entry |
 
 ### Tokens and extensible types
 
@@ -25,7 +25,7 @@
 | `science.alt.dataset.schemaType` | Schema format identifiers (`jsonSchema`, extensible) |
 | `science.alt.dataset.arrayFormat` | Array serialization formats (`ndarrayBytes`, extensible) |
 
-### Storage objects (union members of `record.storage`)
+### Storage objects (union members of `entry.storage`)
 
 | NSID | Description |
 |------|-------------|
@@ -43,19 +43,19 @@
 ## Record relationships
 
 ```
-schema  <----  record  ---->  storage{Http,S3,Blobs}
-  ^            (schemaRef)       (union)
+schema  <----  entry  ---->  storage{Http,S3,Blobs}
+  ^            (schemaRef)      (union)
   |
   |--- lens (sourceSchema, targetSchema)
 
-label  ---->  record
+label  ---->  entry
        (datasetUri)
 ```
 
-- A **record** references a **schema** via `schemaRef` (AT-URI) and contains a **storage** union
+- An **entry** references a **schema** via `schemaRef` (AT-URI) and contains a **storage** union
 - A **lens** connects two **schemas** with bidirectional transformation code
-- A **label** is a named pointer to a **record**, enabling versioned aliases like `mnist@1.0.0`
-- **Storage objects** share the `shardChecksum` type defined in `record#shardChecksum`
+- A **label** is a named pointer to an **entry**, enabling versioned aliases like `mnist@1.0.0`
+- **Storage objects** share the `shardChecksum` type defined in `entry#shardChecksum`
 
 ## Versioning policy
 

--- a/lexicons/science/alt/dataset/entry.json
+++ b/lexicons/science/alt/dataset/entry.json
@@ -1,10 +1,10 @@
 {
   "lexicon": 1,
-  "id": "science.alt.dataset.record",
+  "id": "science.alt.dataset.entry",
   "defs": {
     "main": {
       "type": "record",
-      "description": "Index record for a WebDataset-backed dataset with references to storage location and sample schema",
+      "description": "Index entry for a WebDataset-backed dataset with references to storage location and sample schema",
       "key": "tid",
       "record": {
         "type": "object",
@@ -67,7 +67,7 @@
           "createdAt": {
             "type": "string",
             "format": "datetime",
-            "description": "Timestamp when this dataset record was created"
+            "description": "Timestamp when this dataset entry was created"
           },
           "metadataSchemaRef": {
             "type": "string",

--- a/lexicons/science/alt/dataset/label.json
+++ b/lexicons/science/alt/dataset/label.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "record",
-      "description": "Named label pointing to a dataset record. Multiple labels with the same name but different versions can coexist, enabling versioned references to immutable dataset records.",
+      "description": "Named label pointing to a dataset entry. Multiple labels with the same name but different versions can coexist, enabling versioned references to immutable dataset entries.",
       "key": "tid",
       "record": {
         "type": "object",
@@ -22,7 +22,7 @@
           "datasetUri": {
             "type": "string",
             "format": "at-uri",
-            "description": "AT-URI pointing to the dataset record this label refers to",
+            "description": "AT-URI pointing to the dataset entry this label refers to",
             "maxLength": 500
           },
           "version": {

--- a/lexicons/science/alt/dataset/resolveLabel.json
+++ b/lexicons/science/alt/dataset/resolveLabel.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "query",
-      "description": "Resolve a named dataset label to its underlying dataset record. When version is omitted, resolves to the most recently created label with the given name.",
+      "description": "Resolve a named dataset label to its underlying dataset entry. When version is omitted, resolves to the most recently created label with the given name.",
       "parameters": {
         "type": "params",
         "required": [
@@ -39,11 +39,11 @@
             "uri": {
               "type": "string",
               "format": "at-uri",
-              "description": "AT-URI of the resolved dataset record"
+              "description": "AT-URI of the resolved dataset entry"
             },
             "cid": {
               "type": "string",
-              "description": "CID of the resolved dataset record"
+              "description": "CID of the resolved dataset entry"
             },
             "label": {
               "type": "ref",

--- a/lexicons/science/alt/dataset/storageBlobs.json
+++ b/lexicons/science/alt/dataset/storageBlobs.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "object",
-      "description": "Storage via ATProto PDS blobs for WebDataset tar archives. Used in science.alt.dataset.record storage union for maximum decentralization.",
+      "description": "Storage via ATProto PDS blobs for WebDataset tar archives. Used in science.alt.dataset.entry storage union for maximum decentralization.",
       "required": [
         "blobs"
       ],
@@ -37,7 +37,7 @@
         },
         "checksum": {
           "type": "ref",
-          "ref": "science.alt.dataset.record#shardChecksum",
+          "ref": "science.alt.dataset.entry#shardChecksum",
           "description": "Content hash for integrity verification (optional since PDS blobs have built-in CID integrity)"
         }
       }

--- a/lexicons/science/alt/dataset/storageHttp.json
+++ b/lexicons/science/alt/dataset/storageHttp.json
@@ -36,7 +36,7 @@
         },
         "checksum": {
           "type": "ref",
-          "ref": "science.alt.dataset.record#shardChecksum",
+          "ref": "science.alt.dataset.entry#shardChecksum",
           "description": "Content hash for integrity verification"
         }
       }

--- a/lexicons/science/alt/dataset/storageS3.json
+++ b/lexicons/science/alt/dataset/storageS3.json
@@ -52,7 +52,7 @@
         },
         "checksum": {
           "type": "ref",
-          "ref": "science.alt.dataset.record#shardChecksum",
+          "ref": "science.alt.dataset.entry#shardChecksum",
           "description": "Content hash for integrity verification"
         }
       }


### PR DESCRIPTION
## Summary

- Rename `science.alt.dataset.record` → `science.alt.dataset.entry` to avoid ambiguity with ATProto's concept of a "record"
- Update all cross-references (`#shardChecksum` refs in storageHttp, storageS3, storageBlobs)
- Update description text in label.json, resolveLabel.json, and all docs (README, CLAUDE.md, spec.md)

Closes #5

## Test plan

- [x] `npx lex gen-api` validates all 12 lexicons with zero warnings
- [x] `entry.ts` is generated in codegen output
- [x] No remaining references to `science.alt.dataset.record` in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)