### PR TITLE
release: v0.2.2b1

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,7 @@ name: Validate Lexicons
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
 
 jobs:
@@ -16,3 +16,5 @@ jobs:
       - run: npm install
       - name: Validate lexicon schemas
         run: npx lex gen-api --yes /tmp/validate-output ./lexicons/science/alt/dataset/*.json
+      - name: Validate NSID-to-path mapping
+        run: ./scripts/validate-nsids.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- NSID-to-path validation script (`scripts/validate-nsids.sh`) and CI step to catch drift after namespace renames
+- Environment variable validation in `publish.sh` (fail fast if `GOAT_PDS_HOST`/`GOAT_AUTH` unset)
+
+### Fixed
+
+- `resolveLabel.json` query parameters now have `maxLength` constraints matching their record field counterparts (name: 200, version: 50)
+- Stale "Foundation.ac" reference in `schema.json` `arrayFormatVersions` description
+- `spec.md` incorrectly listed `storageExternal` as a member of `entry.storage` union; moved to new "Deprecated types" section
+- CI push trigger now includes `develop` branch
+
 ## [0.2.1b1] - 2026-02-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.2.2b1] - 2026-02-23
 
 ### Added
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -29,10 +29,15 @@
 
 | NSID | Description |
 |------|-------------|
-| `science.alt.dataset.storageHttp` | HTTP/HTTPS URL-based storage with optional shard manifest |
+| `science.alt.dataset.storageHttp` | HTTP/HTTPS URL-based storage with shard manifest |
 | `science.alt.dataset.storageS3` | S3-compatible object storage |
 | `science.alt.dataset.storageBlobs` | ATProto PDS blob storage |
-| `science.alt.dataset.storageExternal` | *(Deprecated)* External URL storage |
+
+### Deprecated types
+
+| NSID | Description |
+|------|-------------|
+| `science.alt.dataset.storageExternal` | *(Deprecated)* External URL storage; use `storageHttp` or `storageS3` instead. Not included in `entry.storage` union refs. |
 
 ### Non-lexicon schemas
 

--- a/lexicons/science/alt/dataset/resolveLabel.json
+++ b/lexicons/science/alt/dataset/resolveLabel.json
@@ -18,11 +18,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Label name, e.g. 'mnist'"
+            "description": "Label name, e.g. 'mnist'",
+            "maxLength": 200
           },
           "version": {
             "type": "string",
-            "description": "Specific version to resolve. If omitted, resolves to latest."
+            "description": "Specific version to resolve. If omitted, resolves to latest.",
+            "maxLength": 50
           }
         }
       },

--- a/lexicons/science/alt/dataset/schema.json
+++ b/lexicons/science/alt/dataset/schema.json
@@ -106,7 +106,7 @@
         },
         "arrayFormatVersions": {
           "type": "unknown",
-          "description": "Mapping from array format identifiers to semantic versions. Keys are science.alt.dataset.arrayFormat values (e.g., 'ndarrayBytes'), values are semver strings (e.g., '1.0.0'). Foundation.ac maintains canonical shim schemas at https://alt.science/schemas/atdata-{format}-bytes/{version}/."
+          "description": "Mapping from array format identifiers to semantic versions. Keys are science.alt.dataset.arrayFormat values (e.g., 'ndarrayBytes'), values are semver strings (e.g., '1.0.0'). Canonical shim schemas are maintained at https://alt.science/schemas/atdata-{format}-bytes/{version}/."
         }
       }
     }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -18,6 +18,11 @@ if ! command -v goat &> /dev/null; then
     exit 1
 fi
 
+if [ -z "${GOAT_PDS_HOST:-}" ] || [ -z "${GOAT_AUTH:-}" ]; then
+    echo "Error: GOAT_PDS_HOST and GOAT_AUTH environment variables must be set" >&2
+    exit 1
+fi
+
 for lexicon_file in "$LEXICON_DIR"/*.json; do
     nsid=$(basename "$lexicon_file" .json)
     full_nsid="science.alt.dataset.$nsid"

--- a/scripts/validate-nsids.sh
+++ b/scripts/validate-nsids.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Validate that each lexicon file's "id" field matches the NSID derived from its path.
+# This catches drift after namespace renames (which have occurred twice already).
+#
+# Usage:
+#   ./scripts/validate-nsids.sh
+
+set -euo pipefail
+
+LEXICON_DIR="$(cd "$(dirname "$0")/../lexicons" && pwd)"
+errors=0
+
+for file in "$LEXICON_DIR"/science/alt/dataset/*.json; do
+    # Derive expected NSID from path: lexicons/science/alt/dataset/foo.json -> science.alt.dataset.foo
+    relative="${file#"$LEXICON_DIR"/}"
+    expected_nsid="${relative%.json}"
+    expected_nsid="${expected_nsid//\//.}"
+
+    # Extract actual id from the lexicon file
+    actual_nsid=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('$file','utf8')).id)")
+
+    if [ "$actual_nsid" != "$expected_nsid" ]; then
+        echo "MISMATCH: $file" >&2
+        echo "  expected id: $expected_nsid" >&2
+        echo "  actual id:   $actual_nsid" >&2
+        errors=$((errors + 1))
+    fi
+done
+
+if [ "$errors" -gt 0 ]; then
+    echo "$errors NSID mismatch(es) found." >&2
+    exit 1
+fi
+
+echo "All lexicon IDs match their file paths."


### PR DESCRIPTION
## Summary

Adversarial review of v0.2.1b1 lexicon definitions — schema fixes, documentation corrections, CI hardening, and new validation tooling.

### Added
- NSID-to-path validation script (`scripts/validate-nsids.sh`) and CI step to catch drift after namespace renames
- Environment variable validation in `publish.sh` (fail fast if `GOAT_PDS_HOST`/`GOAT_AUTH` unset)

### Fixed
- `resolveLabel.json` query parameters now have `maxLength` constraints matching their record field counterparts (name: 200, version: 50)
- Stale "Foundation.ac" reference in `schema.json` `arrayFormatVersions` description
- `spec.md` incorrectly listed `storageExternal` as a member of `entry.storage` union; moved to new "Deprecated types" section
- CI push trigger now includes `develop` branch

## Test plan

- [x] `npx lex gen-api` — all 12 lexicons validate, 15 files generated
- [x] `./scripts/validate-nsids.sh` — all lexicon IDs match file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)