### PR TITLE
feat: add trust & verification lexicons for lens code references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.2.2b1] - 2026-02-23
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- `science.alt.dataset.lensVerification` record type for attesting to the correctness of a lens at a specific version, following the Bluesky verification pattern
+- `science.alt.dataset.verificationMethod` token type with extensible known values: `codeReview`, `formalProof`, `signedHash`, `automatedTest`
+- Optional `sourceSchemaVersion` and `targetSchemaVersion` fields on `science.alt.dataset.lens` for semver-based schema compatibility matching
+- Trust model documentation in `docs/spec.md`
+
 ## [0.2.2b1] - 2026-02-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Optional `sourceSchemaVersion` and `targetSchemaVersion` fields on `science.alt.dataset.lens` for semver-based schema compatibility matching
 - Trust model documentation in `docs/spec.md`
 
+### Fixed
+
+- `resolveLabel.json` missing `LabelNotFound` error definition (inconsistent with `resolveSchema`'s `SchemaNotFound`)
+- `resolveLabel.json` redundant `#main` suffix on label ref (ATProto convention: bare NSID for main definitions)
+
 ## [0.2.2b1] - 2026-02-23
 
 ### Added

--- a/lexicons/science/alt/dataset/lens.json
+++ b/lexicons/science/alt/dataset/lens.json
@@ -59,6 +59,16 @@
             "ref": "#lensMetadata",
             "description": "Arbitrary metadata (author, performance notes, etc.)"
           },
+          "sourceSchemaVersion": {
+            "type": "string",
+            "description": "Semver version or range for source schema compatibility (e.g., '1.0.0', '>=1.0.0 <2.0.0')",
+            "maxLength": 100
+          },
+          "targetSchemaVersion": {
+            "type": "string",
+            "description": "Semver version or range for target schema compatibility (e.g., '1.0.0', '>=1.0.0 <2.0.0')",
+            "maxLength": 100
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",

--- a/lexicons/science/alt/dataset/lensVerification.json
+++ b/lexicons/science/alt/dataset/lensVerification.json
@@ -1,0 +1,78 @@
+{
+  "lexicon": 1,
+  "id": "science.alt.dataset.lensVerification",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Verification record for a lens transformation. The verifier's identity is implicit — the DID of the repo owner who writes this record. Follows the ATProto pattern where verification records live in the verifier's own PDS.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": [
+          "lens",
+          "lensCommit",
+          "verificationMethod",
+          "createdAt"
+        ],
+        "properties": {
+          "lens": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT-URI of the lens record being verified",
+            "maxLength": 500
+          },
+          "lensCommit": {
+            "type": "string",
+            "description": "CID of the specific lens record version. Ensures immutability — if the lens is updated, old verifications do not carry over.",
+            "maxLength": 128
+          },
+          "verificationMethod": {
+            "type": "ref",
+            "ref": "science.alt.dataset.verificationMethod",
+            "description": "What kind of verification was performed"
+          },
+          "codeHash": {
+            "type": "ref",
+            "ref": "#codeHash",
+            "description": "Hash of the code at the referenced commit. Required for signedHash method."
+          },
+          "proofRef": {
+            "type": "ref",
+            "ref": "science.alt.dataset.lens#codeReference",
+            "description": "Link to proof artifact (Coq/Lean proof, test suite, etc.). Used with formalProof or automatedTest methods."
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of what was verified",
+            "maxLength": 1000
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp when this verification was issued"
+          }
+        }
+      }
+    },
+    "codeHash": {
+      "type": "object",
+      "description": "Content hash for code integrity verification",
+      "required": [
+        "algorithm",
+        "digest"
+      ],
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "description": "Hash algorithm identifier (e.g., 'sha256', 'blake3')",
+          "maxLength": 20
+        },
+        "digest": {
+          "type": "string",
+          "description": "Hex-encoded hash digest",
+          "maxLength": 128
+        }
+      }
+    }
+  }
+}

--- a/lexicons/science/alt/dataset/resolveLabel.json
+++ b/lexicons/science/alt/dataset/resolveLabel.json
@@ -49,12 +49,18 @@
             },
             "label": {
               "type": "ref",
-              "ref": "science.alt.dataset.label#main",
+              "ref": "science.alt.dataset.label",
               "description": "The label record that was resolved"
             }
           }
         }
-      }
+      },
+      "errors": [
+        {
+          "name": "LabelNotFound",
+          "description": "No label found with the given name"
+        }
+      ]
     }
   }
 }

--- a/lexicons/science/alt/dataset/verificationMethod.json
+++ b/lexicons/science/alt/dataset/verificationMethod.json
@@ -1,0 +1,28 @@
+{
+  "lexicon": 1,
+  "id": "science.alt.dataset.verificationMethod",
+  "defs": {
+    "main": {
+      "type": "string",
+      "description": "Verification method identifier for lens verification records. Known values correspond to token definitions in this Lexicon. New verification methods can be added as tokens without breaking changes.",
+      "knownValues": ["codeReview", "formalProof", "signedHash", "automatedTest"],
+      "maxLength": 50
+    },
+    "codeReview": {
+      "type": "token",
+      "description": "Manual code review by a trusted party"
+    },
+    "formalProof": {
+      "type": "token",
+      "description": "Machine-checkable correctness proof (Coq, Lean, etc.)"
+    },
+    "signedHash": {
+      "type": "token",
+      "description": "Cryptographic signature over code hash at referenced commit"
+    },
+    "automatedTest": {
+      "type": "token",
+      "description": "Automated test suite verification"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `science.alt.dataset.lensVerification` record type following Bluesky's verification pattern (verifier writes record into their own PDS, identity is implicit)
- Add `science.alt.dataset.verificationMethod` extensible token type with known values: `codeReview`, `formalProof`, `signedHash`, `automatedTest`
- Add optional `sourceSchemaVersion` / `targetSchemaVersion` fields to `science.alt.dataset.lens` for semver-based schema compatibility matching
- Document trust model and update spec with new record relationships
- Fix: add `LabelNotFound` error to `resolveLabel.json` and normalize redundant `#main` ref (found during adversarial review)

Closes #9

## Test plan

- [x] `npx lex gen-api` validates all lexicons successfully
- [x] `scripts/validate-nsids.sh` confirms NSID-to-path consistency
- [x] Generated TypeScript includes `LabelNotFoundError` class for resolveLabel
- [ ] Review generated TypeScript types for correctness
- [ ] Verify lensVerification fields match design spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)