### PR TITLE
Add language field to codeReference in lens lexicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- `science.alt.dataset.programmingLanguage` token type with extensible known values: `python`, `typescript`, `javascript`, `rust`
+- Optional `language` field on `science.alt.dataset.lens#codeReference` for per-function programming language granularity
+
+### Deprecated
+
+- Top-level `language` field on `science.alt.dataset.lens` records — use `codeReference.language` instead for per-function granularity
+
 ## [0.3.0b1] - 2026-02-24
 
 ### Added

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -25,6 +25,7 @@
 |------|-------------|
 | `science.alt.dataset.schemaType` | Schema format identifiers (`jsonSchema`, extensible) |
 | `science.alt.dataset.arrayFormat` | Array serialization formats (`ndarrayBytes`, extensible) |
+| `science.alt.dataset.programmingLanguage` | Programming language identifiers (`python`, `typescript`, `javascript`, `rust`, extensible) |
 | `science.alt.dataset.verificationMethod` | Verification method identifiers (`codeReview`, `formalProof`, `signedHash`, `automatedTest`, extensible) |
 
 ### Storage objects (union members of `entry.storage`)
@@ -84,4 +85,5 @@ These lexicons follow ATProto evolution conventions:
 - **Additive changes only**: new optional fields, new `knownValues` entries, new union members
 - **No breaking changes**: required fields are never removed, types are never narrowed
 - **Open unions**: storage and schema format unions are open by default, allowing new members without breaking existing consumers
-- **Token extensibility**: `schemaType` and `arrayFormat` use `knownValues` (not `enum`), so new formats can be added without schema changes
+- **Token extensibility**: `schemaType`, `arrayFormat`, and `programmingLanguage` use `knownValues` (not `enum`), so new values can be added without schema changes
+- **Deprecated fields**: The top-level `language` field on `science.alt.dataset.lens` is deprecated in favor of per-reference `codeReference.language`, which allows getter and putter to specify different languages

--- a/lexicons/science/alt/dataset/lens.json
+++ b/lexicons/science/alt/dataset/lens.json
@@ -51,7 +51,7 @@
           },
           "language": {
             "type": "string",
-            "description": "Programming language of the lens implementation (e.g., 'python', 'typescript')",
+            "description": "(Deprecated: use codeReference.language instead.) Programming language of the lens implementation (e.g., 'python', 'typescript')",
             "maxLength": 50
           },
           "metadata": {
@@ -110,6 +110,11 @@
           "type": "string",
           "description": "Optional branch name (for reference, commit hash is authoritative)",
           "maxLength": 100
+        },
+        "language": {
+          "type": "ref",
+          "ref": "science.alt.dataset.programmingLanguage",
+          "description": "Programming language of the code at this reference. Prefer this over the top-level language field for per-function granularity."
         }
       }
     }

--- a/lexicons/science/alt/dataset/programmingLanguage.json
+++ b/lexicons/science/alt/dataset/programmingLanguage.json
@@ -1,0 +1,28 @@
+{
+  "lexicon": 1,
+  "id": "science.alt.dataset.programmingLanguage",
+  "defs": {
+    "main": {
+      "type": "string",
+      "description": "Programming language identifier for code references. Uses Linguist language identifiers (lowercase). Known values correspond to token definitions in this Lexicon. New languages can be added as tokens without breaking changes.",
+      "knownValues": ["python", "typescript", "javascript", "rust"],
+      "maxLength": 50
+    },
+    "python": {
+      "type": "token",
+      "description": "Python programming language."
+    },
+    "typescript": {
+      "type": "token",
+      "description": "TypeScript programming language."
+    },
+    "javascript": {
+      "type": "token",
+      "description": "JavaScript programming language."
+    },
+    "rust": {
+      "type": "token",
+      "description": "Rust programming language."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `science.alt.dataset.programmingLanguage` token lexicon with extensible known values (`python`, `typescript`, `javascript`, `rust`)
- Add optional `language` ref field to `lens#codeReference` for per-function programming language granularity
- Deprecate top-level `language` field on lens records in favor of `codeReference.language`

## Test plan

- [x] `npx lex gen-api` validates all lexicons successfully
- [x] `scripts/validate-nsids.sh` confirms NSID-to-path consistency
- [ ] Review generated TypeScript types for correctness

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)