### PR TITLE
Add automated lexicon publishing on GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish Lexicons
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout tagged ref
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Install goat CLI
+        run: go install github.com/bluesky-social/goat@latest
+
+      - name: Publish lexicons to PDS
+        env:
+          GOAT_PDS_HOST: ${{ secrets.GOAT_PDS_HOST }}
+          GOAT_AUTH: ${{ secrets.GOAT_AUTH }}
+        run: ./scripts/publish.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- GitHub Actions workflow for automated lexicon publishing to ATProto PDS on release
+
 ## [0.3.0b1] - 2026-02-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ npx lex gen-api --yes /tmp/validate-output ./lexicons/science/alt/dataset/*.json
 
 CI runs this on every push and pull request.
 
+## Publishing
+
+Lexicons are automatically published to the ATProto PDS when a GitHub release is created. For manual publishing, run `scripts/publish.sh` with `GOAT_PDS_HOST` and `GOAT_AUTH` environment variables set. See `scripts/publish.sh` for details.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary

- Add `.github/workflows/publish.yml` that auto-publishes lexicons to the ATProto PDS when a GitHub release is created
- Workflow installs the goat CLI, then delegates to the existing `scripts/publish.sh` with secrets from the `production` environment
- Update CHANGELOG and README with publishing documentation

## Test plan

- [ ] Verify workflow YAML is valid (e.g. via `actionlint` or GitHub Actions dry run)
- [ ] Create a draft release to confirm the workflow does **not** trigger (uses `published` event type)
- [ ] Create a non-draft release to confirm the workflow triggers and publishes lexicons
- [ ] Confirm `GOAT_PDS_HOST` and `GOAT_AUTH` secrets are configured in the `production` environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)