### PR TITLE
release: v0.3.0b3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,6 @@ jobs:
 
       - name: Publish lexicons to PDS
         env:
-          GOAT_PDS_HOST: ${{ secrets.GOAT_PDS_HOST }}
-          GOAT_AUTH: ${{ secrets.GOAT_AUTH }}
+          GOAT_USERNAME: ${{ secrets.GOAT_USERNAME }}
+          GOAT_PASSWORD: ${{ secrets.GOAT_PASSWORD }}
         run: ./scripts/publish.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.3.0b3] - 2026-02-24
+
+### Fixed
+
+- Publish script and workflow aligned with goat CLI interface (`goat lex publish --update` replaces broken `--nsid` flag pipeline, auth env vars corrected to `GOAT_USERNAME`/`GOAT_PASSWORD`)
+
 ## [0.3.0b2] - 2026-02-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ CI runs this on every push and pull request.
 
 ## Publishing
 
-Lexicons are automatically published to the ATProto PDS when a GitHub release is created. For manual publishing, run `scripts/publish.sh` with `GOAT_PDS_HOST` and `GOAT_AUTH` environment variables set. See `scripts/publish.sh` for details.
+Lexicons are automatically published to the ATProto PDS when a GitHub release is created. For manual publishing, run `scripts/publish.sh` with `GOAT_USERNAME` and `GOAT_PASSWORD` environment variables set. See `scripts/publish.sh` for details.
 
 ## License
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,39 +2,28 @@
 # Publish lexicon schemas to a PDS as com.atproto.lexicon.schema records.
 #
 # Prerequisites:
-#   - goat CLI (https://github.com/bluesky-social/indigo/tree/main/cmd/goat)
-#   - GOAT_PDS_HOST and GOAT_AUTH environment variables set
+#   - goat CLI (https://github.com/bluesky-social/goat)
+#   - GOAT_USERNAME and GOAT_PASSWORD environment variables set
 #   - DNS _lexicon.dataset.alt.science TXT record pointing to the publishing DID
 #
 # Usage:
-#   ./scripts/publish.sh
+#   GOAT_USERNAME="handle-or-did" GOAT_PASSWORD="app-password" ./scripts/publish.sh
 
 set -euo pipefail
 
-LEXICON_DIR="$(cd "$(dirname "$0")/../lexicons/science/alt/dataset" && pwd)"
+LEXICON_DIR="$(cd "$(dirname "$0")/../lexicons" && pwd)"
 
 if ! command -v goat &> /dev/null; then
-    echo "Error: goat CLI not found. Install from https://github.com/bluesky-social/indigo" >&2
+    echo "Error: goat CLI not found. Install from https://github.com/bluesky-social/goat" >&2
     exit 1
 fi
 
-if [ -z "${GOAT_PDS_HOST:-}" ] || [ -z "${GOAT_AUTH:-}" ]; then
-    echo "Error: GOAT_PDS_HOST and GOAT_AUTH environment variables must be set" >&2
+if [ -z "${GOAT_USERNAME:-}" ] || [ -z "${GOAT_PASSWORD:-}" ]; then
+    echo "Error: GOAT_USERNAME and GOAT_PASSWORD environment variables must be set" >&2
     exit 1
 fi
 
-for lexicon_file in "$LEXICON_DIR"/*.json; do
-    nsid=$(basename "$lexicon_file" .json)
-    full_nsid="science.alt.dataset.$nsid"
-
-    echo "Publishing $full_nsid..."
-
-    # Parse the lexicon file and wrap it as a com.atproto.lexicon.schema record,
-    # then publish it to the PDS.
-    goat lex parse "$lexicon_file" \
-        | goat lex publish --nsid "$full_nsid" -
-
-    echo "  Published $full_nsid"
-done
-
-echo "All lexicons published."
+# goat lex publish scans the lexicons directory, extracts NSIDs from each
+# file's "id" field, and publishes them as com.atproto.lexicon.schema records.
+# --update overwrites existing records if the schema has changed.
+goat lex publish --update --lexicons-dir "$LEXICON_DIR" "$LEXICON_DIR/science/alt/dataset/"


### PR DESCRIPTION
## Summary

- Fix publish script and workflow to align with actual `goat` CLI interface
  - Replace broken `goat lex parse | goat lex publish --nsid` pipeline with `goat lex publish --update`
  - Correct auth env vars from `GOAT_PDS_HOST`/`GOAT_AUTH` to `GOAT_USERNAME`/`GOAT_PASSWORD`

## Test plan

- [x] `npx lex gen-api` validates all 15 lexicon schemas
- [x] `validate-nsids.sh` confirms all NSID-to-path mappings
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)