### PR TITLE
feat!: redesign #jsonSchemaFormat as typed envelope with opaque content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.3.0b3] - 2026-02-24
+
+### Fixed
+
+- Publish script and workflow aligned with goat CLI interface (`goat lex publish --update` replaces broken `--nsid` flag pipeline, auth env vars corrected to `GOAT_USERNAME`/`GOAT_PASSWORD`)
+
 ## [0.3.0b2] - 2026-02-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Changed
+
+- Redesigned `#jsonSchemaFormat` as typed envelope with opaque `content` field to resolve ATProto `$type` conflict with goat CLI publishing
+
+### Fixed
+
+- `schema.json` can now be published via `goat lex publish` (removed explicit `$type` declaration that conflicted with ATProto reserved fields)
+
 ## [0.3.0b3] - 2026-02-24
 
 ### Fixed

--- a/lexicons/science/alt/dataset/schema.json
+++ b/lexicons/science/alt/dataset/schema.json
@@ -83,26 +83,17 @@
     },
     "jsonSchemaFormat": {
       "type": "object",
-      "description": "JSON Schema Draft 7 format for sample type definitions. Used with NDArray shim for array types.",
-      "required": ["$type", "$schema", "type", "properties"],
+      "description": "JSON Schema format for sample type definitions. The content field holds the actual JSON Schema document (Draft 7+). This envelope separates ATProto protocol fields from JSON Schema's $-prefixed fields.",
+      "required": ["draft", "content"],
       "properties": {
-        "$type": {
+        "draft": {
           "type": "string",
-          "const": "science.alt.dataset.schema#jsonSchemaFormat"
+          "const": "draft-07",
+          "description": "JSON Schema draft version identifier"
         },
-        "$schema": {
-          "type": "string",
-          "const": "http://json-schema.org/draft-07/schema#",
-          "description": "JSON Schema version identifier"
-        },
-        "type": {
-          "type": "string",
-          "const": "object",
-          "description": "Sample types must be objects"
-        },
-        "properties": {
+        "content": {
           "type": "unknown",
-          "description": "Field definitions for the sample type (JSON Schema properties object)"
+          "description": "JSON Schema object (e.g., Draft 7). Contains the full schema including $schema, type, properties, etc. Stored as opaque data to avoid $-prefix collisions with ATProto reserved fields."
         },
         "arrayFormatVersions": {
           "type": "unknown",


### PR DESCRIPTION
## Summary

- Redesigns `#jsonSchemaFormat` from directly declaring `$type`/`$schema`/`type`/`properties` to a typed envelope pattern with `draft` + `content` fields
- The `content` field (opaque `unknown` type) holds the full JSON Schema document, avoiding `$`-prefix collisions with ATProto reserved fields
- Resolves goat CLI publishing failure caused by explicit `$type` declaration conflicting with ATProto's implicit `$type` injection

## Changes

- **`lexicons/science/alt/dataset/schema.json`**: Replaced `jsonSchemaFormat` internals — removed `$type`, `$schema`, `type`, `properties`; added `draft` (const `"draft-07"`) and `content` (unknown); `arrayFormatVersions` unchanged
- **`CHANGELOG.md`**: Added `[Unreleased]` section with Changed and Fixed entries

## Test plan

- [x] `npx lex gen-api` validates all lexicons successfully
- [x] `scripts/validate-nsids.sh` passes
- [ ] Verify `goat lex publish` no longer rejects `schema.json`

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)