### PR TITLE
release: v0.4.0b1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- New array format tokens: `sparseBytes`, `structuredBytes`, `arrowTensor`, `safetensors`
+- JSON Schema shim definitions for sparse, structured, arrow tensor, safetensors, and dataframe formats
+- NDArray shim v1.1.0 with optional dtype, shape, and dimension name annotations
+
 ## [0.3.0b3] - 2026-02-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Changed
+
+- Redesigned `#jsonSchemaFormat` as typed envelope with opaque `content` field to resolve ATProto `$type` conflict with goat CLI publishing
+
+### Fixed
+
+- `schema.json` can now be published via `goat lex publish` (removed explicit `$type` declaration that conflicted with ATProto reserved fields)
+
 ## [0.3.0b3] - 2026-02-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.4.0b1] - 2026-02-25
 
 ### Added
 
 - New array format tokens: `sparseBytes`, `structuredBytes`, `arrowTensor`, `safetensors`
 - JSON Schema shim definitions for sparse, structured, arrow tensor, safetensors, and dataframe formats
 - NDArray shim v1.1.0 with optional dtype, shape, and dimension name annotations
+
 ### Changed
 
 - Redesigned `#jsonSchemaFormat` as typed envelope with opaque `content` field to resolve ATProto `$type` conflict with goat CLI publishing

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -24,7 +24,7 @@
 | NSID | Description |
 |------|-------------|
 | `science.alt.dataset.schemaType` | Schema format identifiers (`jsonSchema`, extensible) |
-| `science.alt.dataset.arrayFormat` | Array serialization formats (`ndarrayBytes`, extensible) |
+| `science.alt.dataset.arrayFormat` | Array serialization formats (`ndarrayBytes`, `sparseBytes`, `structuredBytes`, `arrowTensor`, `safetensors`, extensible) |
 | `science.alt.dataset.programmingLanguage` | Programming language identifiers (`python`, `typescript`, `javascript`, `rust`, extensible) |
 | `science.alt.dataset.verificationMethod` | Verification method identifiers (`codeReview`, `formalProof`, `signedHash`, `automatedTest`, extensible) |
 
@@ -46,7 +46,13 @@
 
 | File | Description |
 |------|-------------|
-| `schemas/ndarray_shim.json` | JSON Schema Draft 7 definition for NDArray byte format (numpy `.npy` binary) |
+| `schemas/ndarray_shim.json` | JSON Schema Draft 7 definition for NDArray byte format v1.0.0 (numpy `.npy` binary) |
+| `schemas/ndarray_shim_v1.1.0.json` | NDArray byte format v1.1.0 with optional dtype, shape, and dimension name annotations |
+| `schemas/sparse_shim.json` | JSON Schema Draft 7 definition for scipy sparse matrix format (CSR/CSC/COO) |
+| `schemas/structured_shim.json` | JSON Schema Draft 7 definition for numpy structured array format (compound dtypes) |
+| `schemas/arrow_tensor_shim.json` | JSON Schema Draft 7 definition for Arrow tensor IPC format |
+| `schemas/safetensors_shim.json` | JSON Schema Draft 7 definition for HuggingFace safetensors format |
+| `schemas/dataframe_shim.json` | JSON Schema Draft 7 definition for tabular data in Parquet format |
 
 ## Record relationships
 

--- a/lexicons/science/alt/dataset/arrayFormat.json
+++ b/lexicons/science/alt/dataset/arrayFormat.json
@@ -5,12 +5,28 @@
     "main": {
       "type": "string",
       "description": "Array serialization format identifier for NDArray fields in sample schemas. Known values correspond to token definitions in this Lexicon. Each format has versioned specifications maintained by alt.science at canonical URLs.",
-      "knownValues": ["ndarrayBytes"],
+      "knownValues": ["ndarrayBytes", "sparseBytes", "structuredBytes", "arrowTensor", "safetensors"],
       "maxLength": 50
     },
     "ndarrayBytes": {
       "type": "token",
       "description": "Numpy .npy binary format for NDArray serialization. Stores arrays with dtype and shape in binary header. Versions maintained at https://alt.science/schemas/atdata-ndarray-bytes/{version}/"
+    },
+    "sparseBytes": {
+      "type": "token",
+      "description": "Scipy sparse matrix format (CSR/CSC/COO). Stores sparse matrices with indices and data arrays. Versions maintained at https://alt.science/schemas/atdata-sparse-bytes/{version}/"
+    },
+    "structuredBytes": {
+      "type": "token",
+      "description": "Numpy structured array format. Stores arrays with named, typed fields (compound dtypes). Versions maintained at https://alt.science/schemas/atdata-structured-bytes/{version}/"
+    },
+    "arrowTensor": {
+      "type": "token",
+      "description": "Arrow tensor format. Stores multi-dimensional arrays using Arrow's tensor IPC format. Versions maintained at https://alt.science/schemas/atdata-arrow-tensor/{version}/"
+    },
+    "safetensors": {
+      "type": "token",
+      "description": "Safetensors format (HuggingFace). Stores ML tensors with safe, memory-mapped access. Versions maintained at https://alt.science/schemas/atdata-safetensors/{version}/"
     }
   }
 }

--- a/lexicons/science/alt/dataset/schema.json
+++ b/lexicons/science/alt/dataset/schema.json
@@ -83,26 +83,17 @@
     },
     "jsonSchemaFormat": {
       "type": "object",
-      "description": "JSON Schema Draft 7 format for sample type definitions. Used with NDArray shim for array types.",
-      "required": ["$type", "$schema", "type", "properties"],
+      "description": "JSON Schema format for sample type definitions. The content field holds the actual JSON Schema document (Draft 7+). This envelope separates ATProto protocol fields from JSON Schema's $-prefixed fields.",
+      "required": ["draft", "content"],
       "properties": {
-        "$type": {
+        "draft": {
           "type": "string",
-          "const": "science.alt.dataset.schema#jsonSchemaFormat"
+          "const": "draft-07",
+          "description": "JSON Schema draft version identifier"
         },
-        "$schema": {
-          "type": "string",
-          "const": "http://json-schema.org/draft-07/schema#",
-          "description": "JSON Schema version identifier"
-        },
-        "type": {
-          "type": "string",
-          "const": "object",
-          "description": "Sample types must be objects"
-        },
-        "properties": {
+        "content": {
           "type": "unknown",
-          "description": "Field definitions for the sample type (JSON Schema properties object)"
+          "description": "JSON Schema object (e.g., Draft 7). Contains the full schema including $schema, type, properties, etc. Stored as opaque data to avoid $-prefix collisions with ATProto reserved fields."
         },
         "arrayFormatVersions": {
           "type": "unknown",

--- a/schemas/arrow_tensor_shim.json
+++ b/schemas/arrow_tensor_shim.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://alt.science/schemas/atdata-arrow-tensor/1.0.0",
+  "title": "ATDataArrowTensor",
+  "description": "Standard definition for Arrow tensor types in JSON Schema, compatible with atdata WebDataset serialization. This type's contents are interpreted as containing the raw bytes data for a serialized Arrow tensor, and serve as a marker for atdata-based code generation to use standard Arrow tensor types, rather than generated dataclasses.",
+  "version": "1.0.0",
+  "$defs": {
+    "tensor": {
+      "type": "string",
+      "format": "byte",
+      "description": "Arrow tensor serialized using Arrow IPC tensor format. When represented in JSON, this is a base64-encoded string. In msgpack, this is raw bytes.",
+      "contentEncoding": "base64",
+      "contentMediaType": "application/octet-stream"
+    }
+  }
+}

--- a/schemas/dataframe_shim.json
+++ b/schemas/dataframe_shim.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://alt.science/schemas/atdata-dataframe/1.0.0",
+  "title": "ATDataDataFrame",
+  "description": "Standard definition for tabular DataFrame types in JSON Schema, compatible with atdata WebDataset serialization. This type's contents are interpreted as containing the raw bytes data for a serialized Parquet file, and serve as a marker for atdata-based code generation to use standard DataFrame types, rather than generated dataclasses.",
+  "version": "1.0.0",
+  "$defs": {
+    "dataframe": {
+      "type": "string",
+      "format": "byte",
+      "description": "Tabular data serialized as Parquet format. When represented in JSON, this is a base64-encoded string. In msgpack, this is raw bytes.",
+      "contentEncoding": "base64",
+      "contentMediaType": "application/octet-stream"
+    }
+  }
+}

--- a/schemas/ndarray_shim_v1.1.0.json
+++ b/schemas/ndarray_shim_v1.1.0.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://alt.science/schemas/atdata-ndarray-bytes/1.1.0",
+  "title": "ATDataNDArrayBytes",
+  "description": "Standard definition for numpy NDArray types in JSON Schema, compatible with atdata WebDataset serialization. This version adds optional dtype, shape, and dimension name annotations to the base NDArray byte format.",
+  "version": "1.1.0",
+  "$defs": {
+    "ndarray": {
+      "type": "object",
+      "description": "Numpy array with optional type and shape annotations. The `data` field contains the serialized array bytes, while optional fields provide metadata for validation and code generation without needing to deserialize the array.",
+      "required": ["data"],
+      "properties": {
+        "data": {
+          "type": "string",
+          "format": "byte",
+          "description": "Numpy array serialized using numpy `.npy` format via `np.save` (includes dtype and shape in binary header). When represented in JSON, this is a base64-encoded string. In msgpack, this is raw bytes.",
+          "contentEncoding": "base64",
+          "contentMediaType": "application/octet-stream"
+        },
+        "dtype": {
+          "type": "string",
+          "description": "Numpy dtype string describing the array's data type (e.g., \"float32\", \"int64\", \"complex128\")."
+        },
+        "shape": {
+          "type": "array",
+          "description": "Expected array shape. Each element is an integer dimension size, or null for variable/batch dimensions.",
+          "items": {
+            "type": ["integer", "null"]
+          }
+        },
+        "dimensionNames": {
+          "type": "array",
+          "description": "Human-readable names for each dimension (e.g., [\"batch\", \"height\", \"width\", \"channels\"]).",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/safetensors_shim.json
+++ b/schemas/safetensors_shim.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://alt.science/schemas/atdata-safetensors/1.0.0",
+  "title": "ATDataSafetensors",
+  "description": "Standard definition for HuggingFace safetensors types in JSON Schema, compatible with atdata WebDataset serialization. This type's contents are interpreted as containing the raw bytes data for a serialized safetensors file, and serve as a marker for atdata-based code generation to use standard safetensors types, rather than generated dataclasses.",
+  "version": "1.0.0",
+  "$defs": {
+    "safetensors": {
+      "type": "string",
+      "format": "byte",
+      "description": "HuggingFace safetensors format for ML tensors with safe, memory-mapped access. When represented in JSON, this is a base64-encoded string. In msgpack, this is raw bytes.",
+      "contentEncoding": "base64",
+      "contentMediaType": "application/octet-stream"
+    }
+  }
+}

--- a/schemas/sparse_shim.json
+++ b/schemas/sparse_shim.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://alt.science/schemas/atdata-sparse-bytes/1.0.0",
+  "title": "ATDataSparseBytes",
+  "description": "Standard definition for scipy sparse matrix types in JSON Schema, compatible with atdata WebDataset serialization. This type's contents are interpreted as containing the raw bytes data for a serialized scipy sparse matrix (CSR/CSC/COO), and serve as a marker for atdata-based code generation to use standard scipy sparse types, rather than generated dataclasses.",
+  "version": "1.0.0",
+  "$defs": {
+    "sparse": {
+      "type": "string",
+      "format": "byte",
+      "description": "Scipy sparse matrix serialized using `scipy.sparse.save_npz` format (CSR/CSC/COO with indices and data arrays). When represented in JSON, this is a base64-encoded string. In msgpack, this is raw bytes.",
+      "contentEncoding": "base64",
+      "contentMediaType": "application/octet-stream"
+    }
+  }
+}

--- a/schemas/structured_shim.json
+++ b/schemas/structured_shim.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://alt.science/schemas/atdata-structured-bytes/1.0.0",
+  "title": "ATDataStructuredBytes",
+  "description": "Standard definition for numpy structured array types in JSON Schema, compatible with atdata WebDataset serialization. This type's contents are interpreted as containing the raw bytes data for a serialized numpy structured array, and serve as a marker for atdata-based code generation to use standard numpy structured types, rather than generated dataclasses.",
+  "version": "1.0.0",
+  "$defs": {
+    "structured": {
+      "type": "string",
+      "format": "byte",
+      "description": "Numpy structured array serialized using numpy `.npy` format via `np.save` (includes compound dtype info in header). When represented in JSON, this is a base64-encoded string. In msgpack, this is raw bytes.",
+      "contentEncoding": "base64",
+      "contentMediaType": "application/octet-stream"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

### Added
- New array format tokens: `sparseBytes`, `structuredBytes`, `arrowTensor`, `safetensors`
- JSON Schema shim definitions for sparse, structured, arrow tensor, safetensors, and dataframe formats
- NDArray shim v1.1.0 with optional dtype, shape, and dimension name annotations

### Changed
- **Breaking**: Redesigned `#jsonSchemaFormat` as typed envelope with opaque `content` field to resolve ATProto `$type` conflict with goat CLI publishing

### Fixed
- `schema.json` can now be published via `goat lex publish` (removed explicit `$type` declaration that conflicted with ATProto reserved fields)

## Test plan

- [x] `npx lex gen-api` validates all 15 lexicon schemas
- [x] `validate-nsids.sh` confirms all NSID-to-path mappings
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)