### PR TITLE
feat: add shardManifestRef and manifests to entry lexicon

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -73,6 +73,7 @@ label  ---->  entry
 - A **lensVerification** attests to the correctness of a **lens** at a specific version (`lensCommit`)
 - A **label** is a named pointer to an **entry**, enabling versioned aliases like `mnist@1.0.0`
 - **Storage objects** share the `shardChecksum` type defined in `entry#shardChecksum`
+- An **entry** may include `manifests` — per-shard blob references to a JSON header and optional Parquet samples file for query-based access (`entry#shardManifestRef`)
 
 ## Trust model
 

--- a/lexicons/science/alt/dataset/entry.json
+++ b/lexicons/science/alt/dataset/entry.json
@@ -78,7 +78,41 @@
           "contentMetadata": {
             "type": "unknown",
             "description": "Dataset-level content metadata (e.g., instrument settings, acquisition parameters). Structure is validated against the schema referenced by metadataSchemaRef when present. Stored as an open JSON object."
+          },
+          "manifests": {
+            "type": "array",
+            "description": "Per-shard manifest references for query-based access. Each entry pairs a shard with its manifest header blob and optional Parquet samples blob.",
+            "items": {
+              "type": "ref",
+              "ref": "#shardManifestRef"
+            },
+            "maxLength": 10000
           }
+        }
+      }
+    },
+    "shardManifestRef": {
+      "type": "object",
+      "description": "References to manifest sidecar data for a single shard. The header contains schema info, sample count, and per-field aggregates. The samples file is a Parquet table with per-sample metadata for query-based access.",
+      "required": [
+        "header"
+      ],
+      "properties": {
+        "header": {
+          "type": "blob",
+          "description": "Manifest JSON header blob containing shard-level metadata (schema, sample count, field aggregates)",
+          "accept": [
+            "application/json"
+          ],
+          "maxSize": 1048576
+        },
+        "samples": {
+          "type": "blob",
+          "description": "Optional Parquet file with per-sample metadata for query-based filtering",
+          "accept": [
+            "application/octet-stream"
+          ],
+          "maxSize": 104857600
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds per-shard manifest references to `science.alt.dataset.entry`, enabling query-based access to dataset metadata without downloading full shards.

### Changes

- **New def `entry#shardManifestRef`** — object with:
  - `header` (blob, required): JSON manifest header containing shard-level metadata (schema info, sample count, per-field aggregates). Accepts `application/json`, max 1 MB.
  - `samples` (blob, optional): Parquet file with per-sample metadata for query-based filtering. Accepts `application/octet-stream`, max 100 MB.
- **New property `entry.manifests`** — optional array of `#shardManifestRef`, max 10,000 entries (one per shard).
- **Updated `docs/spec.md`** — documents the new manifest relationship in the record relationships section.

### Versioning

This is an **additive-only change** per the [versioning policy](docs/spec.md#versioning-policy):
- New optional field on an existing record (no existing consumers break)
- New def within the existing `entry` lexicon (no new NSIDs)

### Motivation

The reference implementation ([atdata](https://github.com/forecast-bio/atdata)) already has Python types for this (`ShardManifestRef`, `LexDatasetEntry.manifests`) and uses manifests for efficient query-based dataset access. This PR aligns the lexicon spec with the implementation.

Related: forecast-bio/atdata#89

## Test plan
- [x] `entry.json` validates as JSON
- [x] `scripts/validate-nsids.sh` passes (all lexicon IDs match file paths)
- [x] Downstream atdata test suite passes with this lexicon (1762 tests, 25 lexicon-specific)